### PR TITLE
Backwards compatibility - don't convert None in boolean clauses to NULL

### DIFF
--- a/lib/sqlalchemy/orm/query.py
+++ b/lib/sqlalchemy/orm/query.py
@@ -1298,7 +1298,7 @@ class Query(object):
 
         """
         for criterion in list(criterion):
-            criterion = expression._expression_literal_as_text(criterion)
+            criterion = expression._bool_expression_literal_as_text(criterion)
 
             criterion = self._adapt_clause(criterion, True, True)
 
@@ -1397,7 +1397,7 @@ class Query(object):
 
         """
 
-        criterion = expression._expression_literal_as_text(criterion)
+        criterion = expression._bool_expression_literal_as_text(criterion)
 
         if criterion is not None and \
                 not isinstance(criterion, sql.ClauseElement):

--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -28,7 +28,7 @@ import logging
 import warnings
 
 # This can be set to 'log:LEVEL' to log, 'warning' to warn, or 'error' to raise an Exception; anything else will ignore
-NONE_CLAUSE_HANDLING = 'warning'
+NONE_CLAUSE_HANDLING = 'log:WARN'
 
 
 class NoneClauseWarning(RuntimeWarning):

--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -1924,7 +1924,7 @@ class BooleanClauseList(ClauseList, ColumnElement):
         if NONE_CLAUSE_HANDLING in ("warning", "error") or NONE_CLAUSE_HANDLING.startswith("log:"):
             if not isinstance(clauses, (list, tuple)):
                 clauses = list(clauses)
-            if None in clauses:
+            if type(None) in map(type, clauses):
                 if NONE_CLAUSE_HANDLING == "warning":
                     warnings.warn("Use of None in and_", NoneClauseWarning)
                     clauses = [clause for clause in clauses if clause is not None]
@@ -1968,7 +1968,7 @@ class BooleanClauseList(ClauseList, ColumnElement):
         if NONE_CLAUSE_HANDLING in ("warning", "error") or NONE_CLAUSE_HANDLING.startswith("log:"):
             if not isinstance(clauses, (list, tuple)):
                 clauses = list(clauses)
-            if None in clauses:
+            if type(None) in map(type, clauses):
                 if NONE_CLAUSE_HANDLING == "warning":
                     warnings.warn("Use of None in or_", NoneClauseWarning)
                     clauses = [clause for clause in clauses if clause is not None]
@@ -3794,6 +3794,7 @@ def _bool_expression_literal_as_text(element):
                 logging.log(level, "Use of None in expression")
         return TextClause("")
     return _expression_literal_as_text(element)
+
 
 def _expression_literal_as_text(element):
     return _literal_as_text(element, warn=True)

--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -24,6 +24,21 @@ import numbers
 
 import re
 import operator
+import logging
+import warnings
+
+# This can be set to 'log:LEVEL' to log, 'warning' to warn, or 'error' to raise an Exception; anything else will ignore
+NONE_CLAUSE_HANDLING = 'warning'
+
+
+class NoneClauseWarning(RuntimeWarning):
+    """Indicates that somebody is using None as a a boolean clause, which is usually a problem"""
+    pass
+
+
+class NoneClauseError(RuntimeError):
+    """Indicates that somebody is using None as a a boolean clause, which is usually a problem"""
+    pass
 
 
 def _clone(element, **kw):
@@ -1906,6 +1921,18 @@ class BooleanClauseList(ClauseList, ColumnElement):
             :func:`.or_`
 
         """
+        if NONE_CLAUSE_HANDLING in ("warning", "error") or NONE_CLAUSE_HANDLING.startswith("log:"):
+            if not isinstance(clauses, (list, tuple)):
+                clauses = list(clauses)
+            if None in clauses:
+                if NONE_CLAUSE_HANDLING == "warning":
+                    warnings.warn("Use of None in and_", NoneClauseWarning)
+                    clauses = [clause for clause in clauses if clause is not None]
+                elif NONE_CLAUSE_HANDLING == "error":
+                    raise NoneClauseError("Use of None in and_")
+                else:
+                    level = getattr(logging, NONE_CLAUSE_HANDLING.replace("log:", "", 1).upper(), logging.ERROR)
+                    logging.log(level, "Use of None in and_: %r", clauses)
         return cls._construct(operators.and_, True_, False_, *clauses)
 
     @classmethod
@@ -1938,6 +1965,18 @@ class BooleanClauseList(ClauseList, ColumnElement):
             :func:`.and_`
 
         """
+        if NONE_CLAUSE_HANDLING in ("warning", "error") or NONE_CLAUSE_HANDLING.startswith("log:"):
+            if not isinstance(clauses, (list, tuple)):
+                clauses = list(clauses)
+            if None in clauses:
+                if NONE_CLAUSE_HANDLING == "warning":
+                    warnings.warn("Use of None in or_", NoneClauseWarning)
+                    clauses = [clause for clause in clauses if clause is not None]
+                elif NONE_CLAUSE_HANDLING == "error":
+                    raise NoneClauseError("Use of None in or_")
+                else:
+                    level = getattr(logging, NONE_CLAUSE_HANDLING.replace("log:", "", 1).upper(), logging.ERROR)
+                    logging.log(level, "Use of None in or_: %r", clauses)
         return cls._construct(operators.or_, False_, True_, *clauses)
 
     @property

--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -1933,6 +1933,7 @@ class BooleanClauseList(ClauseList, ColumnElement):
                 else:
                     level = getattr(logging, NONE_CLAUSE_HANDLING.replace("log:", "", 1).upper(), logging.ERROR)
                     logging.log(level, "Use of None in and_: %r", clauses)
+                    clauses = [clause for clause in clauses if clause is not None]
         return cls._construct(operators.and_, True_, False_, *clauses)
 
     @classmethod
@@ -1977,6 +1978,7 @@ class BooleanClauseList(ClauseList, ColumnElement):
                 else:
                     level = getattr(logging, NONE_CLAUSE_HANDLING.replace("log:", "", 1).upper(), logging.ERROR)
                     logging.log(level, "Use of None in or_: %r", clauses)
+                    clauses = [clause for clause in clauses if clause is not None]
         return cls._construct(operators.or_, False_, True_, *clauses)
 
     @property

--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -1783,7 +1783,7 @@ class ClauseList(ClauseElement):
         self.group_contents = kwargs.pop('group_contents', True)
         text_converter = kwargs.pop(
             '_literal_as_text',
-            _expression_literal_as_text)
+            _bool_expression_literal_as_text)
         if self.group_contents:
             self.clauses = [
                 text_converter(clause).self_group(against=self.operator)
@@ -1857,7 +1857,7 @@ class BooleanClauseList(ClauseList, ColumnElement):
 
         clauses = util.coerce_generator_arg(clauses)
         for clause in clauses:
-            clause = _expression_literal_as_text(clause)
+            clause = _bool_expression_literal_as_text(clause)
 
             if isinstance(clause, continue_on):
                 continue
@@ -3004,7 +3004,7 @@ class FunctionFilter(ColumnElement):
         """
 
         for criterion in list(criterion):
-            criterion = _expression_literal_as_text(criterion)
+            criterion = _bool_expression_literal_as_text(criterion)
 
             if self.criterion is not None:
                 self.criterion = self.criterion & criterion
@@ -3780,6 +3780,20 @@ def _literal_and_labels_as_label_reference(element):
     else:
         return _literal_as_text(element)
 
+
+def _bool_expression_literal_as_text(element):
+    """Converts a boolean expression into text, but warn if None is passed in, to avoid NULL boolean expressions"""
+    if element is None:
+        if NONE_CLAUSE_HANDLING in ("warning", "error") or NONE_CLAUSE_HANDLING.startswith("log:"):
+            if NONE_CLAUSE_HANDLING == "warning":
+                warnings.warn("Use of None in expression", NoneClauseWarning, 2)
+            elif NONE_CLAUSE_HANDLING == "error":
+                raise NoneClauseError("Use of None in expression")
+            else:
+                level = getattr(logging, NONE_CLAUSE_HANDLING.replace("log:", "", 1).upper(), logging.ERROR)
+                logging.log(level, "Use of None in expression")
+        return TextClause("")
+    return _expression_literal_as_text(element)
 
 def _expression_literal_as_text(element):
     return _literal_as_text(element, warn=True)

--- a/lib/sqlalchemy/sql/expression.py
+++ b/lib/sqlalchemy/sql/expression.py
@@ -109,7 +109,7 @@ from .elements import _literal_as_text, _clause_element_as_expr,\
     _truncated_label, _clone, _cloned_difference, _cloned_intersection,\
     _column_as_key, _literal_as_binds, _select_iterables, \
     _corresponding_column_or_error, _literal_as_label_reference, \
-    _expression_literal_as_text
+    _expression_literal_as_text, _bool_expression_literal_as_text
 from .selectable import _interpret_as_from
 
 


### PR DESCRIPTION
In sqlalchemy 0.9, a [change was made](http://docs.sqlalchemy.org/en/rel_0_9/changelog/migration_09.html?highlight=and_#improved-rendering-of-boolean-constants-null-constants-conjunctions) to the [handling of None in boolean expressions](http://docs.sqlalchemy.org/en/rel_0_9/changelog/migration_09.html?highlight=and_#none-can-no-longer-be-used-as-a-partial-and-constructor). The effect of this change was that boolean clause sequences containing `None` elements would render those elements as `NULL`, rather than simply leaving them out of the `WHERE` clause.

In order to maintain backwards compatibility, this patch will try to handle `None`s in `and_`, `or_`, and some standard boolean expression receiving functions (notably `filter`), resolving them to empty sql `text` strings. (The old `and_(None)` returned `None`, but that's problematic with the new code. Returning `text('')` has an equivalent effect while working with the new paradigm).

In addition, provision is made for logging messages, raising exceptions, or using the `warnings` module when `None`s are received in these places. By default, a warning message is logged. To alter this, do one of the following (`INFO` can be replaced with any valid logging level):

``` python
from sqlalchemy.sql import elements
elements.NONE_CLAUSE_HANDLING = 'log:INFO'
elements.NONE_CLAUSE_HANDLING = 'error'
elements.NONE_CLAUSE_HANDLING = 'warning'
```

This patch is against release `1.0.6` of sqlalchemy
