### PR TITLE
Bumped version number for private j5 release, and added explanation

### DIFF
--- a/doc/build/changelog/changelog_10.rst
+++ b/doc/build/changelog/changelog_10.rst
@@ -16,6 +16,14 @@
         :start-line: 5
 
 .. changelog::
+    :version: 1.0.6+j5.1
+    :released: June 25, 2015
+        :tags: bug
+
+        Added backwards compatibility modification for Nones in boolean clauses.
+        See [the merge request](https://github.com/j5int/sqlalchemy/pull/1/) for details.
+
+    .. change::
     :version: 1.0.6
     :released: June 25, 2015
 

--- a/lib/sqlalchemy/__init__.py
+++ b/lib/sqlalchemy/__init__.py
@@ -120,7 +120,7 @@ from .schema import (
 from .inspection import inspect
 from .engine import create_engine, engine_from_config
 
-__version__ = '1.0.6'
+__version__ = '1.0.6+j5.1'
 
 
 def __go(lcls):


### PR DESCRIPTION
Made a private version number following [PEP 0440](https://www.python.org/dev/peps/pep-0440/#local-version-identifiers)
Added some notes to the changelog
