### PR TITLE
Cherry pick: Add use_nchar_for_unicode flag; don't use nchar types for generic unicode

### DIFF
--- a/doc/build/changelog/unreleased_13/4242.rst
+++ b/doc/build/changelog/unreleased_13/4242.rst
@@ -1,0 +1,18 @@
+.. change::
+    :tags: bug, oracle
+    :tickets: 4242
+
+    The Oracle dialect will no longer use the NCHAR/NCLOB datatypes
+    represent generic unicode strings or clob fields in conjunction with
+    :class:`.Unicode` and :class:`.UnicodeText` unless the flag
+    ``use_nchar_for_unicode=True`` is passed to :func:`.create_engine` -
+    this includes CREATE TABLE behavior as well as ``setinputsizes()`` for
+    bound parameters.   On the read side, automatic Unicode conversion under
+    Python 2 has been added to CHAR/VARCHAR/CLOB result rows, to match the
+    behavior of cx_Oracle under Python 3.  In order to mitigate the performance
+    hit under Python 2, SQLAlchemy's very performant (when C extensions
+    are built) native Unicode handlers are used under Python 2.
+
+    .. seealso::
+
+        :ref:`change_4242`

--- a/lib/sqlalchemy/dialects/oracle/base.py
+++ b/lib/sqlalchemy/dialects/oracle/base.py
@@ -554,7 +554,7 @@ class OracleTypeCompiler(compiler.GenericTypeCompiler):
         return self.visit_FLOAT(type_, **kw)
 
     def visit_unicode(self, type_, **kw):
-        if self.dialect._supports_nchar:
+        if self.dialect._use_nchar_for_unicode:
             return self.visit_NVARCHAR2(type_, **kw)
         else:
             return self.visit_VARCHAR2(type_, **kw)
@@ -642,7 +642,7 @@ class OracleTypeCompiler(compiler.GenericTypeCompiler):
         return self.visit_CLOB(type_, **kw)
 
     def visit_unicode_text(self, type_, **kw):
-        if self.dialect._supports_nchar:
+        if self.dialect._use_nchar_for_unicode:
             return self.visit_NCLOB(type_, **kw)
         else:
             return self.visit_CLOB(type_, **kw)
@@ -1104,6 +1104,9 @@ class OracleDialect(default.DefaultDialect):
     execution_ctx_cls = OracleExecutionContext
 
     reflection_options = ("oracle_resolve_synonyms",)
+
+    _use_nchar_for_unicode = False
+
     construct_arguments = [
         (
             sa_schema.Table,
@@ -1112,15 +1115,15 @@ class OracleDialect(default.DefaultDialect):
         (sa_schema.Index, {"bitmap": False, "compress": False}),
     ]
 
-    def __init__(
-        self,
-        use_ansi=True,
-        optimize_limits=False,
-        use_binds_for_limits=True,
-        exclude_tablespaces=("SYSTEM", "SYSAUX"),
-        **kwargs
-    ):
+    def __init__(self,
+                 use_ansi=True,
+                 optimize_limits=False,
+                 use_binds_for_limits=True,
+                 use_nchar_for_unicode=False,
+                 exclude_tablespaces=("SYSTEM", "SYSAUX", ),
+                 **kwargs):
         default.DefaultDialect.__init__(self, **kwargs)
+        self._use_nchar_for_unicode = use_nchar_for_unicode
         self.use_ansi = use_ansi
         self.optimize_limits = optimize_limits
         self.use_binds_for_limits = use_binds_for_limits
@@ -1153,13 +1156,19 @@ class OracleDialect(default.DefaultDialect):
     def _supports_char_length(self):
         return not self._is_oracle_8
 
-    @property
-    def _supports_nchar(self):
-        return not self._is_oracle_8
-
     def do_release_savepoint(self, connection, name):
         # Oracle does not support RELEASE SAVEPOINT
         pass
+
+    def _check_unicode_returns(self, connection):
+        additional_tests = [
+            expression.cast(
+                expression.literal_column("'test nvarchar2 returns'"),
+                sqltypes.NVARCHAR(60)
+            ),
+        ]
+        return super(OracleDialect, self)._check_unicode_returns(
+            connection, additional_tests)
 
     def has_table(self, connection, table_name, schema=None):
         if not schema:

--- a/lib/sqlalchemy/dialects/oracle/cx_oracle.py
+++ b/lib/sqlalchemy/dialects/oracle/cx_oracle.py
@@ -75,76 +75,46 @@ The parameters accepted by the cx_oracle dialect are as follows:
 Unicode
 -------
 
-The cx_Oracle DBAPI as of version 5 fully supports unicode, and has the
-ability to return string results as Python unicode objects natively.
+The cx_Oracle DBAPI as of version 5 fully supports Unicode, and has the
+ability to return string results as Python Unicode objects natively.
 
-When used in Python 3, cx_Oracle returns all strings as Python unicode objects
-(that is, plain ``str`` in Python 3).  In Python 2, it will return as Python
-unicode those column values that are of type ``NVARCHAR`` or ``NCLOB``.  For
-column values that are of type ``VARCHAR`` or other non-unicode string types,
-it will return values as Python strings (e.g. bytestrings).
+Explicit Unicode support is available by using the :class:`.Unicode` datatype
+with SQLAlchemy Core expression language, as well as the :class:`.UnicodeText`
+datatype.  These types correspond to the  VARCHAR2 and CLOB Oracle datatypes by
+default.   When using these datatypes with Unicode data, it is expected that
+the Oracle database is configured with a Unicode-aware character set, as well
+as that the ``NLS_LANG`` environment variable is set appropriately, so that
+the VARCHAR2 and CLOB datatypes can accommodate the data.
 
-The cx_Oracle SQLAlchemy dialect presents several different options for the use
-case of receiving ``VARCHAR`` column values as Python unicode objects under
-Python 2:
+In the case that the Oracle database is not configured with a Unicode character
+set, the two options are to use the :class:`.oracle.NCHAR` and
+:class:`.oracle.NCLOB` datatypes explicitly, or to pass the flag
+``use_nchar_for_unicode=True`` to :func:`.create_engine`, which will cause the
+SQLAlchemy dialect to use NCHAR/NCLOB for the :class:`.Unicode` /
+:class:`.UnicodeText` datatypes instead of VARCHAR/CLOB.
 
-* When using Core expression objects as well as the ORM, SQLAlchemy's
-  unicode-decoding services are available, which are established by
-  using either the :class:`.Unicode` datatype or by using the
-  :class:`.String` datatype with :paramref:`.String.convert_unicode` set
-  to True.
+.. versionchanged:: 1.3  The :class:`.Unicode` and :class:`.UnicodeText`
+   datatypes now correspond to the ``VARCHAR2`` and ``CLOB`` Oracle datatypes
+   unless the ``use_nchar_for_unicode=True`` is passed to the dialect
+   when :func:`.create_engine` is called.
 
-* When using raw SQL strings, typing behavior can be added for unicode
-  conversion using the :func:`.text` construct::
+When result sets are fetched that include strings, under Python 3 the cx_Oracle
+DBAPI returns all strings as Python Unicode objects, since Python 3 only has a
+Unicode string type.  This occurs for data fetched from datatypes such as
+VARCHAR2, CHAR, CLOB, NCHAR, NCLOB, etc.  In order to provide cross-
+compatibility under Python 2, the SQLAlchemy cx_Oracle dialect will add
+Unicode-conversion to string data under Python 2 as well.  Historically, this
+made use of converters that were supplied by cx_Oracle but were found to be
+non-performant; SQLAlchemy's own converters are used for the string to Unicode
+conversion under Python 2.  To disable the Python 2 Unicode conversion for
+VARCHAR2, CHAR, and CLOB, the flag ``coerce_to_unicode=False`` can be passed to
+:func:`.create_engine`.
 
-    from sqlalchemy import text, Unicode
-    result = conn.execute(
-        text("select username from user").columns(username=Unicode))
+.. versionchanged:: 1.3 Unicode conversion is applied to all string values
+   by default under python 2.  The ``coerce_to_unicode`` now defaults to True
+   and can be set to False to disable the Unicode coersion of strings that are
+   delivered as VARCHAR2/CHAR/CLOB data.
 
-* Otherwise, when using raw SQL strings sent directly to an ``.execute()``
-  method without any Core typing behavior added, the flag
-  ``coerce_to_unicode=True`` flag can be passed to :func:`.create_engine`
-  which will add an unconditional unicode processor to cx_Oracle for all
-  string values::
-
-    engine = create_engine("oracle+cx_oracle://dsn", coerce_to_unicode=True)
-
-  The above approach will add significant latency to result-set fetches
-  of plain string values.
-
-Sending String Values as Unicode or Non-Unicode
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-As of SQLAlchemy 1.2.2, the cx_Oracle dialect unconditionally calls
-``setinputsizes()`` for bound values that are passed as Python unicode objects.
-In Python 3, all string values are Unicode; for cx_Oracle, this corresponds to
-``cx_Oracle.NCHAR`` being passed to ``setinputsizes()`` for that parameter.
-In some edge cases, such as passing format specifiers for
-the ``trunc()`` function, Oracle does not accept these as NCHAR::
-
-    from sqlalchemy import func
-
-    conn.execute(
-        func.trunc(func.sysdate(), 'dd')
-    )
-
-In these cases, an error as follows may be raised::
-
-    ORA-01899: bad precision specifier
-
-When this error is encountered, it may be necessary to pass the string value
-with an explicit non-unicode type::
-
-    from sqlalchemy import func
-    from sqlalchemy import literal
-    from sqlalchemy import String
-
-    conn.execute(
-        func.trunc(func.sysdate(), literal('dd', String))
-    )
-
-For full control over this ``setinputsizes()`` behavior, see the section
-:ref:`cx_oracle_setinputsizes`
 
 .. _cx_oracle_setinputsizes:
 
@@ -212,7 +182,6 @@ series.   This setting can be modified as follows::
         for bindparam, dbapitype in list(inputsizes.items()):
             if dbapitype is CLOB:
                 del inputsizes[bindparam]
-
 
 .. _cx_oracle_returning:
 
@@ -305,7 +274,7 @@ import collections
 import decimal
 import random
 import re
-
+from ...util import compat
 from . import base as oracle
 from .base import OracleCompiler
 from .base import OracleDialect
@@ -456,9 +425,24 @@ class _OracleChar(sqltypes.CHAR):
         return dbapi.FIXED_CHAR
 
 
-class _OracleNVarChar(sqltypes.NVARCHAR):
+class _OracleUnicodeStringNCHAR(oracle.NVARCHAR2):
     def get_dbapi_type(self, dbapi):
         return dbapi.NCHAR
+
+
+class _OracleUnicodeStringCHAR(sqltypes.Unicode):
+    def get_dbapi_type(self, dbapi):
+        return None
+
+
+class _OracleUnicodeTextNCLOB(oracle.NCLOB):
+    def get_dbapi_type(self, dbapi):
+        return dbapi.NCLOB
+
+
+class _OracleUnicodeTextCLOB(sqltypes.UnicodeText):
+    def get_dbapi_type(self, dbapi):
+        return dbapi.CLOB
 
 
 class _OracleText(sqltypes.Text):
@@ -484,11 +468,6 @@ class _OracleEnum(sqltypes.Enum):
             return raw_str
 
         return process
-
-
-class _OracleUnicodeText(sqltypes.UnicodeText):
-    def get_dbapi_type(self, dbapi):
-        return dbapi.NCLOB
 
 
 class _OracleBinary(sqltypes.LargeBinary):
@@ -732,13 +711,15 @@ class OracleDialect_cx_oracle(OracleDialect):
         oracle.INTERVAL: _OracleInterval,
         sqltypes.Text: _OracleText,
         sqltypes.String: _OracleString,
-        sqltypes.UnicodeText: _OracleUnicodeText,
+        sqltypes.UnicodeText: _OracleUnicodeTextCLOB,
         sqltypes.CHAR: _OracleChar,
         sqltypes.Enum: _OracleEnum,
         oracle.LONG: _OracleLong,
         oracle.RAW: _OracleRaw,
-        sqltypes.Unicode: _OracleNVarChar,
-        sqltypes.NVARCHAR: _OracleNVarChar,
+        sqltypes.Unicode: _OracleUnicodeStringCHAR,
+        sqltypes.NVARCHAR: _OracleUnicodeStringNCHAR,
+        sqltypes.NCHAR: _OracleUnicodeStringNCHAR,
+        oracle.NCLOB: _OracleUnicodeTextNCLOB,
         oracle.ROWID: _OracleRowid,
     }
 
@@ -748,7 +729,7 @@ class OracleDialect_cx_oracle(OracleDialect):
         self,
         auto_convert_lobs=True,
         threaded=True,
-        coerce_to_unicode=False,
+        coerce_to_unicode=True,
         coerce_to_decimal=True,
         arraysize=50,
         **kwargs
@@ -762,6 +743,10 @@ class OracleDialect_cx_oracle(OracleDialect):
         self.auto_convert_lobs = auto_convert_lobs
         self.coerce_to_unicode = coerce_to_unicode
         self.coerce_to_decimal = coerce_to_decimal
+        if self._use_nchar_for_unicode:
+            self.colspecs = self.colspecs.copy()
+            self.colspecs[sqltypes.Unicode] = _OracleUnicodeStringNCHAR
+            self.colspecs[sqltypes.UnicodeText] = _OracleUnicodeTextNCLOB
 
         cx_Oracle = self.dbapi
 
@@ -917,15 +902,38 @@ class OracleDialect_cx_oracle(OracleDialect):
                     )
 
             # allow all strings to come back natively as Unicode
-            elif dialect.coerce_to_unicode and default_type in (
-                cx_Oracle.STRING,
-                cx_Oracle.FIXED_CHAR,
-            ):
-                return cursor.var(util.text_type, size, cursor.arraysize)
+            elif dialect.coerce_to_unicode and \
+                    default_type in (cx_Oracle.STRING, cx_Oracle.FIXED_CHAR):
+                if compat.py2k:
+                    outconverter = processors.to_unicode_processor_factory(
+                        dialect.encoding, None)
+                    return cursor.var(
+                        cx_Oracle.STRING, size, cursor.arraysize,
+                        outconverter=outconverter
+                    )
+                else:
+                    return cursor.var(
+                        util.text_type, size, cursor.arraysize
+                    )
+
             elif dialect.auto_convert_lobs and default_type in (
-                cx_Oracle.CLOB,
-                cx_Oracle.NCLOB,
-                cx_Oracle.BLOB,
+                    cx_Oracle.CLOB, cx_Oracle.NCLOB
+            ):
+                if compat.py2k:
+                    outconverter = processors.to_unicode_processor_factory(
+                        dialect.encoding, None)
+                    return cursor.var(
+                        default_type, size, cursor.arraysize,
+                        outconverter=lambda value: outconverter(value.read())
+                    )
+                else:
+                    return cursor.var(
+                        default_type, size, cursor.arraysize,
+                        outconverter=lambda value: value.read()
+                    )
+
+            elif dialect.auto_convert_lobs and default_type in (
+                    cx_Oracle.BLOB,
             ):
                 return cursor.var(
                     default_type,

--- a/test/dialect/oracle/test_dialect.py
+++ b/test/dialect/oracle/test_dialect.py
@@ -171,13 +171,12 @@ class CompatFlagsTest(fixtures.TestBase, AssertsCompiledSQL):
 
         # before connect, assume modern DB
         assert dialect._supports_char_length
-        assert dialect._supports_nchar
         assert dialect.use_ansi
+        assert not dialect._use_nchar_for_unicode
 
         dialect.initialize(Mock())
         assert not dialect.implicit_returning
         assert not dialect._supports_char_length
-        assert not dialect._supports_nchar
         assert not dialect.use_ansi
         self.assert_compile(String(50), "VARCHAR2(50)", dialect=dialect)
         self.assert_compile(Unicode(50), "VARCHAR2(50)", dialect=dialect)
@@ -193,19 +192,29 @@ class CompatFlagsTest(fixtures.TestBase, AssertsCompiledSQL):
         dialect = self._dialect(None)
 
         assert dialect._supports_char_length
-        assert dialect._supports_nchar
+        assert not dialect._use_nchar_for_unicode
         assert dialect.use_ansi
         self.assert_compile(String(50), "VARCHAR2(50 CHAR)", dialect=dialect)
-        self.assert_compile(Unicode(50), "NVARCHAR2(50)", dialect=dialect)
-        self.assert_compile(UnicodeText(), "NCLOB", dialect=dialect)
+        self.assert_compile(Unicode(50), "VARCHAR2(50 CHAR)", dialect=dialect)
+        self.assert_compile(UnicodeText(), "CLOB", dialect=dialect)
 
     def test_ora10_flags(self):
         dialect = self._dialect((10, 2, 5))
 
         dialect.initialize(Mock())
         assert dialect._supports_char_length
-        assert dialect._supports_nchar
+        assert not dialect._use_nchar_for_unicode
         assert dialect.use_ansi
+        self.assert_compile(String(50), "VARCHAR2(50 CHAR)", dialect=dialect)
+        self.assert_compile(Unicode(50), "VARCHAR2(50 CHAR)", dialect=dialect)
+        self.assert_compile(UnicodeText(), "CLOB", dialect=dialect)
+
+    def test_use_nchar(self):
+        dialect = self._dialect((10, 2, 5), use_nchar_for_unicode=True)
+
+        dialect.initialize(Mock())
+        assert dialect._use_nchar_for_unicode
+
         self.assert_compile(String(50), "VARCHAR2(50 CHAR)", dialect=dialect)
         self.assert_compile(Unicode(50), "NVARCHAR2(50)", dialect=dialect)
         self.assert_compile(UnicodeText(), "NCLOB", dialect=dialect)

--- a/test/dialect/oracle/test_types.py
+++ b/test/dialect/oracle/test_types.py
@@ -85,15 +85,33 @@ class DialectTypesTest(fixtures.TestBase, AssertsCompiledSQL):
             (DATE(), cx_oracle._OracleDate),
             (oracle.DATE(), oracle.DATE),
             (String(50), cx_oracle._OracleString),
-            (Unicode(), cx_oracle._OracleNVarChar),
+            (Unicode(), cx_oracle._OracleUnicodeStringCHAR),
             (Text(), cx_oracle._OracleText),
-            (UnicodeText(), cx_oracle._OracleUnicodeText),
-            (NCHAR(), cx_oracle._OracleNVarChar),
+            (UnicodeText(), cx_oracle._OracleUnicodeTextCLOB),
+            (NCHAR(), cx_oracle._OracleUnicodeStringNCHAR),
+            (NVARCHAR(), cx_oracle._OracleUnicodeStringNCHAR),
             (oracle.RAW(50), cx_oracle._OracleRaw),
         ]:
             assert isinstance(
                 start.dialect_impl(dialect), test
             ), "wanted %r got %r" % (test, start.dialect_impl(dialect))
+
+    def test_type_adapt_nchar(self):
+        dialect = cx_oracle.dialect(use_nchar_for_unicode=True)
+
+        for start, test in [
+            (String(), String),
+            (VARCHAR(), cx_oracle._OracleString),
+            (String(50), cx_oracle._OracleString),
+            (Unicode(), cx_oracle._OracleUnicodeStringNCHAR),
+            (Text(), cx_oracle._OracleText),
+            (UnicodeText(), cx_oracle._OracleUnicodeTextNCLOB),
+            (NCHAR(), cx_oracle._OracleUnicodeStringNCHAR),
+            (NVARCHAR(), cx_oracle._OracleUnicodeStringNCHAR),
+        ]:
+            assert isinstance(
+                start.dialect_impl(dialect), test), \
+                "wanted %r got %r" % (test, start.dialect_impl(dialect))
 
     def test_raw_compile(self):
         self.assert_compile(oracle.RAW(), "RAW")
@@ -111,6 +129,24 @@ class DialectTypesTest(fixtures.TestBase, AssertsCompiledSQL):
 
     def test_varchar_types(self):
         dialect = oracle.dialect()
+        for typ, exp in [
+            (String(50), "VARCHAR2(50 CHAR)"),
+            (Unicode(50), "VARCHAR2(50 CHAR)"),
+            (NVARCHAR(50), "NVARCHAR2(50)"),
+            (VARCHAR(50), "VARCHAR(50 CHAR)"),
+            (oracle.NVARCHAR2(50), "NVARCHAR2(50)"),
+            (oracle.VARCHAR2(50), "VARCHAR2(50 CHAR)"),
+            (String(), "VARCHAR2"),
+            (Unicode(), "VARCHAR2"),
+            (NVARCHAR(), "NVARCHAR2"),
+            (VARCHAR(), "VARCHAR"),
+            (oracle.NVARCHAR2(), "NVARCHAR2"),
+            (oracle.VARCHAR2(), "VARCHAR2"),
+        ]:
+            self.assert_compile(typ, exp, dialect=dialect)
+
+    def test_varchar_use_nchar_types(self):
+        dialect = oracle.dialect(use_nchar_for_unicode=True)
         for typ, exp in [
             (String(50), "VARCHAR2(50 CHAR)"),
             (Unicode(50), "NVARCHAR2(50)"),
@@ -695,12 +731,12 @@ class TypesTest(fixtures.TestBase):
         testing.requires.python3, "cx_oracle always returns unicode on py3k"
     )
     def test_coerce_to_unicode(self):
-        engine = testing_engine(options=dict(coerce_to_unicode=True))
+        engine = testing_engine(options=dict(coerce_to_unicode=False))
         value = engine.scalar("SELECT 'hello' FROM DUAL")
-        assert isinstance(value, util.text_type)
+        assert isinstance(value, util.binary_type)
 
         value = testing.db.scalar("SELECT 'hello' FROM DUAL")
-        assert isinstance(value, util.binary_type)
+        assert isinstance(value, util.text_type)
 
     @testing.provide_metadata
     def test_reflect_dates(self):
@@ -761,13 +797,30 @@ class TypesTest(fixtures.TestBase):
         t2 = Table("tnv", m2, autoload=True)
         assert isinstance(t2.c.data.type, sqltypes.NVARCHAR)
 
-        if testing.against("oracle+cx_oracle"):
-            # nvarchar returns unicode natively.  cx_oracle
-            # _OracleNVarChar type should be at play here.
+        if testing.against('oracle+cx_oracle'):
             assert isinstance(
                 t2.c.data.type.dialect_impl(testing.db.dialect),
-                cx_oracle._OracleNVarChar,
-            )
+                cx_oracle._OracleUnicodeStringNCHAR)
+
+        data = u('m’a réveillé.')
+        t2.insert().execute(data=data)
+        res = t2.select().execute().first()['data']
+        eq_(res, data)
+        assert isinstance(res, util.text_type)
+
+    @testing.provide_metadata
+    def test_reflect_unicode_no_nvarchar(self):
+        metadata = self.metadata
+        Table('tnv', metadata, Column('data', sqltypes.Unicode(255)))
+        metadata.create_all()
+        m2 = MetaData(testing.db)
+        t2 = Table('tnv', m2, autoload=True)
+        assert isinstance(t2.c.data.type, sqltypes.VARCHAR)
+
+        if testing.against('oracle+cx_oracle'):
+            assert isinstance(
+                t2.c.data.type.dialect_impl(testing.db.dialect),
+                cx_oracle._OracleString)
 
         data = u("m’a réveillé.")
         t2.insert().execute(data=data)
@@ -1038,7 +1091,8 @@ class SetInputSizesTest(fixtures.TestBase):
     __backend__ = True
 
     @testing.provide_metadata
-    def _test_setinputsizes(self, datatype, value, sis_value):
+    def _test_setinputsizes(
+            self, datatype, value, sis_value, set_nchar_flag=False):
         class TestTypeDec(TypeDecorator):
             impl = NullType()
 
@@ -1074,7 +1128,12 @@ class SetInputSizesTest(fixtures.TestBase):
             def __getattr__(self, key):
                 return getattr(self.cursor, key)
 
-        with testing.db.connect() as conn:
+        if set_nchar_flag:
+            engine = testing_engine(options={"use_nchar_for_unicode": True})
+        else:
+            engine = testing.db
+
+        with engine.connect() as conn:
             connection_fairy = conn.connection
             for tab in [t1, t2, t3]:
                 with mock.patch.object(
@@ -1126,10 +1185,23 @@ class SetInputSizesTest(fixtures.TestBase):
     def test_double_precision_setinputsizes(self):
         self._test_setinputsizes(oracle.DOUBLE_PRECISION, 25.34534, None)
 
+    def test_unicode_nchar_mode(self):
+        self._test_setinputsizes(
+            Unicode(30), u("test"), testing.db.dialect.dbapi.NCHAR,
+            set_nchar_flag=True)
+
+    def test_unicodetext_nchar_mode(self):
+        self._test_setinputsizes(
+            UnicodeText(), u("test"), testing.db.dialect.dbapi.NCLOB,
+            set_nchar_flag=True)
+
     def test_unicode(self):
         self._test_setinputsizes(
-            Unicode(30), u("test"), testing.db.dialect.dbapi.NCHAR
-        )
+            Unicode(30), u("test"), None)
+
+    def test_unicodetext(self):
+        self._test_setinputsizes(
+            UnicodeText(), u("test"), testing.db.dialect.dbapi.CLOB)
 
     def test_string(self):
         self._test_setinputsizes(String(30), "test", None)


### PR DESCRIPTION
The Oracle dialect will no longer use the NCHAR/NCLOB datatypes to
represent generic unicode strings or clob fields in conjunction with
:class:`.Unicode` and :class:`.UnicodeText` unless the flag
``use_nchar_for_unicode=True`` is passed to :func:`.create_engine`.
Additionally, string types under Oracle now coerce to unicode under Python
2 in all cases, however unlike in previous iterations, we use SQLAlchemy's
native unicode handlers which are very performant (when C extensions are
enabled; when they are not, we use cx_Oracle's handlers).

Change-Id: I3939012e9396520875bc52e69bf81f27393836ee
Fixes: #4242
Cherry-picked from 8afee47