### PR TITLE
Implementing the get_unique_constraints method for mssql.

### DIFF
--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -2521,6 +2521,35 @@ class MSDialect(default.DefaultDialect):
 
     @reflection.cache
     @_db_plus_owner
+    def get_unique_constraints(
+            self, connection, tablename, dbname, owner, schema, **kw
+    ):
+        TC = ischema.constraints
+        C = ischema.key_constraints.alias("C")
+
+        s = sql.select(
+            [C.c.column_name, TC.c.constraint_type, C.c.constraint_name],
+            sql.and_(
+                TC.c.constraint_name == C.c.constraint_name,
+                TC.c.table_schema == C.c.table_schema,
+                C.c.table_name == tablename,
+                C.c.table_schema == owner,
+            ),
+        )
+        c = connection.execute(s)
+
+        uniques = {}
+        for row in c:
+            if "UNIQUE" in row[TC.c.constraint_type.name]:
+                uniques.setdefault(row[C.c.constraint_name.name], {"column_names": []})
+                uniques[row[TC.c.constraint_name.name]]["column_names"].append(row[C.c.column_name.name])
+        return [
+            {"name": name, "column_names": uc["column_names"]}
+            for name, uc in uniques.items()
+        ]
+
+    @reflection.cache
+    @_db_plus_owner
     def get_foreign_keys(
         self, connection, tablename, dbname, owner, schema, **kw
     ):

--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -2497,13 +2497,12 @@ class MSDialect(default.DefaultDialect):
         self, connection, tablename, dbname, owner, schema, **kw
     ):
         pkeys = []
-        C, TC, constraint_data = self._get_constraints(connection, owner, tablename)
+        C, TC, constraint_data = self._get_constraints(connection, owner, tablename, "PRIMARY")
         constraint_name = None
         for row in constraint_data:
-            if "PRIMARY" in row[TC.c.constraint_type.name]:
-                pkeys.append(row[0])
-                if constraint_name is None:
-                    constraint_name = row[C.c.constraint_name.name]
+            pkeys.append(row[0])
+            if constraint_name is None:
+                constraint_name = row[C.c.constraint_name.name]
         return {"constrained_columns": pkeys, "name": constraint_name}
 
     @reflection.cache
@@ -2511,29 +2510,34 @@ class MSDialect(default.DefaultDialect):
     def get_unique_constraints(
             self, connection, tablename, dbname, owner, schema, **kw
     ):
-        C, TC, constraint_data = self._get_constraints(connection, owner, tablename)
+        C, TC, constraint_data = self._get_constraints(connection, owner, tablename, "UNIQUE")
 
         uniques = {}
         for row in constraint_data:
-            if "UNIQUE" in row[TC.c.constraint_type.name]:
-                uniques.setdefault(row[C.c.constraint_name.name], {"column_names": []})
-                uniques[row[TC.c.constraint_name.name]]["column_names"].append(row[C.c.column_name.name])
+            uniques.setdefault(row[C.c.constraint_name.name], {"column_names": []})
+            uniques[row[TC.c.constraint_name.name]]["column_names"].append(row[C.c.column_name.name])
         return [
             {"name": name, "column_names": uc["column_names"]}
             for name, uc in uniques.items()
         ]
 
-    def _get_constraints(self, connection, owner, tablename):
+    def _get_constraints(self, connection, owner, tablename, constraint=None):
         TC = ischema.constraints
         C = ischema.key_constraints.alias("C")
+
+        where_clause = [
+            TC.c.constraint_name == C.c.constraint_name,
+            TC.c.table_schema == C.c.table_schema,
+            C.c.table_name == tablename,
+            C.c.table_schema == owner
+        ]
+
+        if constraint:
+            where_clause.append(TC.c.constraint_type.contains(constraint))
+
         s = sql.select(
             [C.c.column_name, TC.c.constraint_type, C.c.constraint_name],
-            sql.and_(
-                TC.c.constraint_name == C.c.constraint_name,
-                TC.c.table_schema == C.c.table_schema,
-                C.c.table_name == tablename,
-                C.c.table_schema == owner,
-            ),
+            sql.and_(*where_clause),
         )
 
         return C, TC, connection.execute(s)


### PR DESCRIPTION
Previously the mssql dialect of sqlalchemy had not implemented the `get_unique_constraints` method. This change implements this method by refactoring out a `_get_constraints` method.

