### PR TITLE
Fix logging and warnings imports in elements.py

### DIFF
--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -43,6 +43,8 @@ from .. import exc
 from .. import inspection
 from .. import util
 
+import logging
+import warnings
 
 def collate(expression, collation):
     """Return the clause ``expression COLLATE collation``.

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,7 +86,7 @@ sqlcipher =
     sqlcipher3_binary;python_version>="3"
 
 [egg_info]
-tag_build = dev
+tag_build = +j5.2
 
 [options.packages.find]
 where = lib


### PR DESCRIPTION
In my previous pull request, I'd missed two imports, and somehow hadn't exercised that code path. This puts the imports in place, and also puts in place the config to tag the wheels correctly.